### PR TITLE
fix: handle bracketed game names from issue template

### DIFF
--- a/.github/workflows/compat-report.yml
+++ b/.github/workflows/compat-report.yml
@@ -160,7 +160,10 @@ jobs:
             const canonical = existingIssues
               .filter((item) => !item.pull_request)
               .filter((item) => item.number !== issue.number)
-              .filter((item) => String(item.title || "").startsWith(`${report.titleId} `))
+              .filter((item) => {
+                const parsed = helpers.parseIssueTitle(item.title || "");
+                return parsed && parsed.titleId === report.titleId;
+              })
               .sort((left, right) => left.number - right.number)[0];
 
             let canonicalIssueUrl = issue.html_url;

--- a/scripts/compat-data.cjs
+++ b/scripts/compat-data.cjs
@@ -137,9 +137,14 @@ function parseIssueTitle(title) {
   if (!match) {
     return null;
   }
+  let gameName = match[2].trim();
+  const wrapped = gameName.match(/^\[(.+)\]$/);
+  if (wrapped) {
+    gameName = wrapped[1].trim();
+  }
   return {
     titleId: match[1].toUpperCase(),
-    gameName: match[2].trim(),
+    gameName,
   };
 }
 


### PR DESCRIPTION
The issue template uses "[TITLE_ID] — [GAME_NAME]" but
parseIssueTitle captured the wrapping brackets as part of the game
name (e.g. "[Midnight Club: Los Angeles]"), and the canonical-issue
duplicate detection used startsWith("<titleId> ") which never matched
template-formatted titles, so duplicate reports were never linked.

Strip wrapping brackets in parseIssueTitle (preserving brackets that
are actually part of the title), and have compat-report dedupe via
parseIssueTitle so it works regardless of bracket usage.