### PR TITLE
Fix compatibility report workflow failures

### DIFF
--- a/.github/ISSUE_TEMPLATE/compatibility_report.yml
+++ b/.github/ISSUE_TEMPLATE/compatibility_report.yml
@@ -1,6 +1,6 @@
 name: Compatibility Report
 description: Report game compatibility with XeniOS
-title: "[TITLE_ID] — [GAME_NAME]"
+title: "[Compatibility Report] "
 labels: ["compat-report"]
 
 body:
@@ -12,6 +12,8 @@ body:
         Please fill out all fields below to submit a compatibility report. If you need help or have a support question, please use the [XeniOS Discord](https://discord.gg/xenios) instead.
 
         **How to find the Title ID:** Open the game in XeniOS and check the title bar or log output for the 8-character hex ID (e.g. `4D5307E6`).
+
+        The workflow uses the required Game Name and Title ID fields below and will correct the issue title automatically.
 
         **Build trust:** GitHub issue and Discord reports are always recorded as self-built / unverified. Only reports submitted from CI-distributed XeniOS builds can count as official Release or Preview compatibility data.
 
@@ -26,6 +28,24 @@ body:
           required: true
         - label: This is not a tech support request
           required: true
+
+  - type: input
+    id: game-name
+    attributes:
+      label: Game Name
+      description: The game title shown by XeniOS
+      placeholder: "e.g., Halo 3"
+    validations:
+      required: true
+
+  - type: input
+    id: title-id
+    attributes:
+      label: Title ID
+      description: The exact 8-character hexadecimal Title ID shown by XeniOS
+      placeholder: "e.g., 4D5307E6"
+    validations:
+      required: true
 
   - type: dropdown
     id: platform

--- a/.github/ISSUE_TEMPLATE/compatibility_report.yml
+++ b/.github/ISSUE_TEMPLATE/compatibility_report.yml
@@ -13,6 +13,8 @@ body:
 
         **How to find the Title ID:** Open the game in XeniOS and check the title bar or log output for the 8-character hex ID (e.g. `4D5307E6`).
 
+        **Build trust:** GitHub issue and Discord reports are always recorded as self-built / unverified. Only reports submitted from CI-distributed XeniOS builds can count as official Release or Preview compatibility data.
+
   - type: checkboxes
     id: validation
     attributes:

--- a/.github/workflows/compat-rebuild.yml
+++ b/.github/workflows/compat-rebuild.yml
@@ -34,6 +34,11 @@ jobs:
             const helpers = require("./scripts/compat-data.cjs");
 
             const existingGames = JSON.parse(fs.readFileSync("data/compatibility.json", "utf8"));
+            const trustedAuthorAssociations = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
+            function trustWorkerMetadataFor(item) {
+              const association = String(item?.author_association || "").toUpperCase();
+              return trustedAuthorAssociations.has(association) || item?.user?.type === "Bot";
+            }
             const carryForward = new Map();
             for (const game of existingGames) {
               carryForward.set(String(game.titleId || "").toUpperCase(), {
@@ -81,7 +86,9 @@ jobs:
 
               const reports = [];
               if (issue.body) {
-                const bodyReport = helpers.parseReportFromMarkdown(issue.body, issue.created_at);
+                const bodyReport = helpers.parseReportFromMarkdown(issue.body, issue.created_at, {
+                  trustWorkerMetadata: trustWorkerMetadataFor(issue),
+                });
                 if (bodyReport) {
                   reports.push(bodyReport);
                 }
@@ -94,7 +101,9 @@ jobs:
               });
 
               for (const comment of comments) {
-                const parsed = helpers.parseReportFromMarkdown(comment.body, comment.created_at);
+                const parsed = helpers.parseReportFromMarkdown(comment.body, comment.created_at, {
+                  trustWorkerMetadata: trustWorkerMetadataFor(comment),
+                });
                 if (parsed) {
                   reports.push(parsed);
                 }

--- a/.github/workflows/compat-rebuild.yml
+++ b/.github/workflows/compat-rebuild.yml
@@ -22,13 +22,14 @@ jobs:
       contains(github.event.issue.labels.*.name, 'compat-report')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: main
 
       - name: Rebuild compatibility.json from GitHub issues
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
+          retries: 3
           script: |
             const fs = require("fs");
             const helpers = require("./scripts/compat-data.cjs");
@@ -153,6 +154,7 @@ jobs:
         run: node scripts/build-discussions.mjs
 
       - name: Commit rebuilt data
+        id: commit
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -160,11 +162,14 @@ jobs:
           if ! git diff --staged --quiet; then
             git commit -m "compat: rebuild canonical data [skip ci]"
             git push
+            echo "changed=true" >> "$GITHUB_OUTPUT"
           else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
             echo "No changes"
           fi
 
       - name: Notify website mirror
+        if: steps.commit.outputs.changed == 'true'
         env:
           WEBSITE_REPO_PAT: ${{ secrets.WEBSITE_REPO_PAT }}
         run: |

--- a/.github/workflows/compat-report.yml
+++ b/.github/workflows/compat-report.yml
@@ -2,7 +2,7 @@ name: Process Compatibility Report
 
 on:
   issues:
-    types: [opened]
+    types: [opened, edited]
 
 permissions:
   contents: write
@@ -17,21 +17,35 @@ jobs:
     if: contains(github.event.issue.labels.*.name, 'compat-report')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: main
 
       - name: Parse issue and update canonical data
-        uses: actions/github-script@v7
+        id: process
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require("fs");
             const helpers = require("./scripts/compat-data.cjs");
             const issue = context.payload.issue;
             const sentinel = "<!-- xenios-auto -->";
+            core.setOutput("processed", "false");
 
             if ((issue.body || "").includes(sentinel)) {
               core.info("Skipping auto-generated issue");
+              return;
+            }
+
+            const issueLabels = (issue.labels || []).map((label) =>
+              typeof label === "string" ? label : label.name || ""
+            );
+            const processedLabelPrefixes = ["state:", "perf:", "platform:", "gpu:", "channel:"];
+            const alreadyProcessed = processedLabelPrefixes.every((prefix) =>
+              issueLabels.some((label) => label.startsWith(prefix))
+            );
+            if (context.payload.action === "edited" && alreadyProcessed) {
+              core.info("Skipping edit for an already processed report");
               return;
             }
 
@@ -40,13 +54,13 @@ jobs:
             if (!report || errors.length > 0) {
               const extra = errors.length > 0
                 ? errors.map((error) => `- ${error}`).join("\n")
-                : '- Issue title must match "TITLE_ID — Game Name".';
+                : "- Game Name and an 8-character hexadecimal Title ID are required.";
               await github.rest.issues.createComment({
                 ...context.repo,
                 issue_number: issue.number,
                 body: `⚠️ Could not process this report automatically.\n\n${extra}\n\n${sentinel}`,
               });
-              core.setFailed("Issue validation failed");
+              core.warning(`Issue validation failed: ${errors.join("; ")}`);
               return;
             }
 
@@ -151,6 +165,15 @@ jobs:
               labels: reportLabels,
             });
 
+            const canonicalIssueTitle = `${report.titleId} — ${report.title}`;
+            if (String(issue.title || "").trim() !== canonicalIssueTitle) {
+              await github.rest.issues.update({
+                ...context.repo,
+                issue_number: issue.number,
+                title: canonicalIssueTitle,
+              });
+            }
+
             const existingIssues = await github.paginate(github.rest.issues.listForRepo, {
               ...context.repo,
               labels: "compat-report",
@@ -224,13 +247,16 @@ jobs:
               };
             });
             fs.writeFileSync("data/compatibility.json", JSON.stringify(refreshed, null, 2) + "\n");
+            core.setOutput("processed", "true");
 
       - name: Rebuild discussions snapshot
+        if: steps.process.outputs.processed == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: node scripts/build-discussions.mjs
 
       - name: Commit compatibility data
+        if: steps.process.outputs.processed == 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -243,6 +269,7 @@ jobs:
           fi
 
       - name: Notify website mirror
+        if: steps.process.outputs.processed == 'true'
         env:
           WEBSITE_REPO_PAT: ${{ secrets.WEBSITE_REPO_PAT }}
         run: |

--- a/scripts/build-discussions.mjs
+++ b/scripts/build-discussions.mjs
@@ -164,6 +164,7 @@ function extractReportMeta(markdown) {
     ["Build Channel", "buildChannel"],
     ["XeniOS Version", "appVersion"],
     ["Build Number", "buildNumber"],
+    ["Build Stage", "buildStage"],
     ["Commit Short", "commitShort"],
     ["Submitted By", "submittedBy"],
   ];

--- a/scripts/build-discussions.mjs
+++ b/scripts/build-discussions.mjs
@@ -16,6 +16,8 @@ const DEFAULT_OWNER = "xenios-jp";
 const DEFAULT_REPO = "game-compatibility";
 const DISCUSSION_LABEL = "compat-report";
 const MAX_DISCUSSION_ENTRIES = 6;
+const MAX_GITHUB_ATTEMPTS = 4;
+const RETRYABLE_GITHUB_STATUSES = new Set([408, 429, 500, 502, 503, 504]);
 
 const owner = process.env.GITHUB_OWNER || process.env.GITHUB_REPOSITORY_OWNER || DEFAULT_OWNER;
 const repo =
@@ -61,13 +63,57 @@ function githubHeaders() {
   return headers;
 }
 
-async function githubFetch(url) {
-  const response = await fetch(url, { headers: githubHeaders() });
-  if (!response.ok) {
-    const body = await response.text();
-    throw new Error(`GitHub request failed (${response.status}): ${body}`);
+function retryDelayMs(response, attempt) {
+  const retryAfter = response?.headers.get("retry-after");
+  if (retryAfter) {
+    const seconds = Number(retryAfter);
+    if (Number.isFinite(seconds)) {
+      return Math.min(Math.max(seconds * 1000, 0), 30_000);
+    }
+
+    const timestamp = Date.parse(retryAfter);
+    if (!Number.isNaN(timestamp)) {
+      return Math.min(Math.max(timestamp - Date.now(), 0), 30_000);
+    }
   }
-  return response;
+
+  return 1000 * 2 ** (attempt - 1);
+}
+
+function wait(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function githubFetch(url) {
+  for (let attempt = 1; attempt <= MAX_GITHUB_ATTEMPTS; attempt += 1) {
+    let response;
+    try {
+      response = await fetch(url, { headers: githubHeaders() });
+    } catch (error) {
+      if (attempt === MAX_GITHUB_ATTEMPTS) {
+        const detail = error instanceof Error ? error.message : String(error);
+        throw new Error(`GitHub request failed after ${attempt} attempts: ${detail}`);
+      }
+      await wait(retryDelayMs(null, attempt));
+      continue;
+    }
+
+    if (response.ok) {
+      return response;
+    }
+
+    const body = await response.text();
+    const retryable =
+      RETRYABLE_GITHUB_STATUSES.has(response.status) ||
+      (response.status === 403 && response.headers.has("retry-after"));
+    if (!retryable || attempt === MAX_GITHUB_ATTEMPTS) {
+      throw new Error(`GitHub request failed (${response.status}): ${body}`);
+    }
+
+    await wait(retryDelayMs(response, attempt));
+  }
+
+  throw new Error("GitHub request failed without a response");
 }
 
 async function listIssues() {

--- a/scripts/compat-data.cjs
+++ b/scripts/compat-data.cjs
@@ -155,6 +155,19 @@ function parseIssueTitle(title) {
   };
 }
 
+function normalizeIssueFormText(raw) {
+  const value = String(raw || "").trim();
+  return value === "_No response_" ? "" : value;
+}
+
+function normalizeIssueFormTitleId(raw) {
+  return normalizeIssueFormText(raw)
+    .replace(/^`+|`+$/g, "")
+    .replace(/^\[|\]$/g, "")
+    .trim()
+    .toUpperCase();
+}
+
 function sanitizeBuildFragment(value) {
   return String(value || "")
     .trim()
@@ -605,6 +618,9 @@ function validateNormalizedReport(report) {
     errors.push("Title ID must be an 8-character hex value.");
   }
   if (!report.title) errors.push("Title is required.");
+  if (report.title && report.title.length > 200) {
+    errors.push("Title must be 200 characters or fewer.");
+  }
   if (!VALID_STATUSES.includes(report.status)) {
     errors.push(`Status must be one of: ${VALID_STATUSES.join(", ")}.`);
   }
@@ -623,6 +639,15 @@ function validateNormalizedReport(report) {
     errors.push(`GPU backend must be one of: ${VALID_GPU_BACKENDS.join(", ")}.`);
   }
   if (!report.notes) errors.push("Notes are required.");
+  if (report.status === "nothing" && report.perf !== "n/a") {
+    errors.push('Reports with status "nothing" must use performance "n/a".');
+  }
+  if (report.status && report.status !== "nothing" && report.perf === "n/a") {
+    errors.push('Performance "n/a" is only valid when the game does not boot.');
+  }
+  if (report.platform === "ios" && report.arch !== "arm64") {
+    errors.push("iOS reports can only use ARM64.");
+  }
   if (report.platform === "ios" && report.gpuBackend !== "msl") {
     errors.push("iOS reports can only use MSL.");
   }
@@ -633,9 +658,17 @@ function validateNormalizedReport(report) {
 }
 
 function normalizeIssueFormReport(issue, sections) {
-  const titleInfo = parseIssueTitle(issue.title || "");
+  const formTitleId = normalizeIssueFormTitleId(sections["Title ID"] || "");
+  const formGameName = normalizeIssueFormText(sections["Game Name"] || "");
+  const hasFormIdentity = Boolean(formTitleId || formGameName);
+  const titleInfo = hasFormIdentity
+    ? { titleId: formTitleId, gameName: formGameName }
+    : parseIssueTitle(issue.title || "");
   if (!titleInfo) {
-    return { report: null, errors: ['Issue title must match "TITLE_ID — Game Name".'] };
+    return {
+      report: null,
+      errors: ["Game Name and an 8-character hexadecimal Title ID are required."],
+    };
   }
 
   const platform = normalizePlatform(sections["Platform"] || "");

--- a/scripts/compat-data.cjs
+++ b/scripts/compat-data.cjs
@@ -16,6 +16,8 @@ const VALID_PLATFORMS = ["ios", "macos"];
 const VALID_ARCHS = ["arm64", "x86_64"];
 const VALID_GPU_BACKENDS = ["msl", "msc"];
 const VALID_CHANNELS = ["release", "preview", "self-built"];
+const VALID_STAGES = ["alpha", "beta", "rc", "stable"];
+const REPORT_METADATA_PREFIX = "xenios-report-meta:";
 const SOURCE_FOOTERS = {
   app: "*Submitted via XeniOS in-app reporter*",
   discord: "*Submitted via Discord /report*",
@@ -132,6 +134,11 @@ function normalizeChannel(raw) {
   return null;
 }
 
+function normalizeStage(raw) {
+  const lower = String(raw || "").toLowerCase().trim();
+  return VALID_STAGES.includes(lower) ? lower : null;
+}
+
 function parseIssueTitle(title) {
   const match = String(title || "").match(/^\[?([A-Fa-f0-9]{8})\]?\s*[—–-]\s*(.+?)$/);
   if (!match) {
@@ -166,6 +173,87 @@ function makeBuildId(platform, channel, appVersion, buildNumber) {
   return parts.length >= 3 ? parts.join("-") : null;
 }
 
+function encodeReportMetadata(source, build) {
+  return Buffer.from(JSON.stringify({ source, build }), "utf8")
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/g, "");
+}
+
+function decodeReportMetadata(text) {
+  const match = String(text || "").match(/<!--\s*xenios-report-meta:([A-Za-z0-9_-]+)\s*-->/i);
+  if (!match) {
+    return null;
+  }
+  try {
+    const normalized = match[1].replace(/-/g, "+").replace(/_/g, "/");
+    const padding = normalized.length % 4 === 0 ? "" : "=".repeat(4 - (normalized.length % 4));
+    return JSON.parse(Buffer.from(normalized + padding, "base64").toString("utf8"));
+  } catch (_error) {
+    return null;
+  }
+}
+
+function normalizeWorkerBuildMetadata(build, platform) {
+  if (!build || typeof build !== "object") {
+    return null;
+  }
+
+  const channel = VALID_CHANNELS.includes(build.channel) ? build.channel : null;
+  const appVersion = String(build.appVersion || "").trim();
+  const buildNumber = String(build.buildNumber || "").trim();
+  const stage = normalizeStage(build.stage);
+  const commitShort = String(build.commitShort || "").trim();
+  const publishedAt = String(build.publishedAt || "").trim();
+  const buildId =
+    String(build.buildId || "").trim() ||
+    makeBuildId(platform, channel || "self-built", appVersion, buildNumber) ||
+    null;
+
+  if (!channel && !appVersion && !buildNumber && !stage && !commitShort && !buildId) {
+    return null;
+  }
+
+  return {
+    buildId: buildId || undefined,
+    channel: channel || "self-built",
+    official: Boolean(build.official),
+    appVersion: appVersion || undefined,
+    buildNumber: buildNumber || undefined,
+    stage: stage || undefined,
+    commitShort: commitShort || undefined,
+    publishedAt: publishedAt || undefined,
+  };
+}
+
+function coerceUnverifiedBuild(build, platform) {
+  if (!build) {
+    return null;
+  }
+
+  const appVersion = String(build.appVersion || "").trim();
+  const buildNumber = String(build.buildNumber || "").trim();
+  const stage = normalizeStage(build.stage);
+  const commitShort = String(build.commitShort || "").trim();
+  const publishedAt = String(build.publishedAt || "").trim();
+  const buildId =
+    makeBuildId(platform, "self-built", appVersion, buildNumber) ||
+    String(build.buildId || "").trim() ||
+    null;
+
+  return {
+    buildId: buildId || undefined,
+    channel: "self-built",
+    official: false,
+    appVersion: appVersion || undefined,
+    buildNumber: buildNumber || undefined,
+    stage: stage || undefined,
+    commitShort: commitShort || undefined,
+    publishedAt: publishedAt || undefined,
+  };
+}
+
 function parseBuildFromSections(sections, platform) {
   const channel =
     normalizeChannel(sections["Build Channel"] || sections["Release Channel"] || sections["Channel"]) ||
@@ -174,6 +262,7 @@ function parseBuildFromSections(sections, platform) {
     sections["XeniOS Version"] || sections["App Version"] || sections["Version"] || ""
   ).trim();
   const buildNumber = String(sections["Build Number"] || sections["Build"] || "").trim();
+  const stage = normalizeStage(sections["Build Stage"] || sections["Stage"] || "");
   const commitShort = String(
     sections["Commit Short"] || sections["Commit"] || sections["Commit Hash"] || ""
   ).trim();
@@ -182,7 +271,7 @@ function parseBuildFromSections(sections, platform) {
     String(sections["Build ID"] || "").trim() ||
     null;
 
-  if (!buildId && !appVersion && !buildNumber && !commitShort) {
+  if (!buildId && !appVersion && !buildNumber && !stage && !commitShort) {
     return null;
   }
 
@@ -192,6 +281,7 @@ function parseBuildFromSections(sections, platform) {
     official: channel !== "self-built",
     appVersion: appVersion || undefined,
     buildNumber: buildNumber || undefined,
+    stage: stage || undefined,
     commitShort: commitShort || undefined,
   };
 }
@@ -268,13 +358,14 @@ function parseBuildFromMarkdownFields(fields, platform) {
   const channel = normalizeChannel(fields["Build Channel"] || fields["Channel"]) || null;
   const appVersion = String(fields["XeniOS Version"] || fields["App Version"] || "").trim();
   const buildNumber = String(fields["Build Number"] || "").trim();
+  const stage = normalizeStage(fields["Build Stage"] || fields["Stage"] || "");
   const commitShort = String(fields["Commit Short"] || fields["Commit"] || "").trim();
   const buildId =
     makeBuildId(platform, channel || "release", appVersion, buildNumber) ||
     String(fields["Build ID"] || "").trim() ||
     null;
 
-  if (!channel && !appVersion && !buildNumber && !commitShort && !buildId) {
+  if (!channel && !appVersion && !buildNumber && !stage && !commitShort && !buildId) {
     return null;
   }
 
@@ -284,12 +375,15 @@ function parseBuildFromMarkdownFields(fields, platform) {
     official: (channel || "release") !== "self-built",
     appVersion: appVersion || undefined,
     buildNumber: buildNumber || undefined,
+    stage: stage || undefined,
     commitShort: commitShort || undefined,
   };
 }
 
-function parseReportFromMarkdown(text, createdAt) {
+function parseReportFromMarkdown(text, createdAt, options = {}) {
+  const trustWorkerMetadata = Boolean(options.trustWorkerMetadata);
   const fields = parseMarkdownTableFields(text);
+  const metadata = trustWorkerMetadata ? decodeReportMetadata(text) : null;
   const status = normalizeStatus(fields["Status"] || "");
   const platform = normalizePlatform(fields["Platform"] || "");
   const device = canonicalizeDeviceName(fields["Device"] || "");
@@ -308,7 +402,10 @@ function parseReportFromMarkdown(text, createdAt) {
   const gpuBackend = normalizeGpuBackend(fields["GPU Backend"] || "") || "msl";
   const notes = extractNotes(text);
   const submittedBy = String(fields["Submitted By"] || "").trim() || undefined;
-  const build = parseBuildFromMarkdownFields(fields, platform);
+  const parsedBuild = parseBuildFromMarkdownFields(fields, platform);
+  const workerBuild = normalizeWorkerBuildMetadata(metadata && metadata.build, platform);
+  const build = workerBuild || coerceUnverifiedBuild(parsedBuild, platform);
+  const source = (metadata && typeof metadata.source === "string" ? metadata.source : parseSource(text));
 
   return {
     device,
@@ -320,7 +417,7 @@ function parseReportFromMarkdown(text, createdAt) {
     perf: perf || (status === "nothing" ? "n/a" : undefined),
     date: new Date(createdAt).toISOString().slice(0, 10),
     notes,
-    source: parseSource(text),
+    source,
     submittedBy,
     build,
   };
@@ -473,8 +570,10 @@ function buildMarkdownReportBody(report, source, screenshotUrls = [], submittedB
 
   if (build) {
     if (build.channel) lines.push(`| **Build Channel** | ${build.channel} |`);
+    lines.push(`| **Build Trust** | ${build.official ? "Verified CI build" : "Self-built / unverified"} |`);
     if (build.appVersion) lines.push(`| **XeniOS Version** | ${build.appVersion} |`);
     if (build.buildNumber) lines.push(`| **Build Number** | ${build.buildNumber} |`);
+    if (build.stage) lines.push(`| **Build Stage** | ${build.stage} |`);
     if (build.commitShort) lines.push(`| **Commit Short** | \`${build.commitShort}\` |`);
   }
   if (submittedBy) {
@@ -490,7 +589,13 @@ function buildMarkdownReportBody(report, source, screenshotUrls = [], submittedB
     });
   }
 
-  lines.push("", "---", SOURCE_FOOTERS[source] || SOURCE_FOOTERS.github, "<!-- xenios-auto -->");
+  lines.push(
+    "",
+    "---",
+    SOURCE_FOOTERS[source] || SOURCE_FOOTERS.github,
+    `<!-- ${REPORT_METADATA_PREFIX}${encodeReportMetadata(source, build || { channel: "self-built", official: false })} -->`,
+    "<!-- xenios-auto -->"
+  );
   return lines.join("\n");
 }
 
@@ -540,7 +645,7 @@ function normalizeIssueFormReport(issue, sections) {
     (status === "nothing" ? "n/a" : null);
   const arch = normalizeArch(sections["Architecture"] || "");
   const gpuBackend = normalizeGpuBackend(sections["GPU Backend"] || "");
-  const build = parseBuildFromSections(sections, platform || "ios");
+  const build = coerceUnverifiedBuild(parseBuildFromSections(sections, platform || "ios"), platform || "ios");
 
   const report = {
     titleId: titleInfo.titleId,

--- a/scripts/compat-data.test.cjs
+++ b/scripts/compat-data.test.cjs
@@ -1,0 +1,90 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const helpers = require("./compat-data.cjs");
+
+function validSections(overrides = {}) {
+  return {
+    "Game Name": "Halo 3",
+    "Title ID": "4D5307E6",
+    Platform: "iOS",
+    Device: "iPhone 15",
+    "OS Version": "26.0",
+    Architecture: "ARM64",
+    "GPU Backend": "MSL (Metal Shading Language)",
+    "Compatibility Status": "Playable — Game can be played start to finish with minor issues",
+    Performance: "Great — Runs at or near full speed",
+    "XeniOS Version": "2.0.1",
+    "Build Channel": "Release",
+    "Build Number": "9730",
+    Notes: "Campaign reaches gameplay.",
+    ...overrides,
+  };
+}
+
+test("uses required form identity when the issue title is unchanged", () => {
+  const { report, errors } = helpers.normalizeIssueFormReport(
+    { title: "[Compatibility Report]" },
+    validSections()
+  );
+
+  assert.deepEqual(errors, []);
+  assert.equal(report.titleId, "4D5307E6");
+  assert.equal(report.title, "Halo 3");
+  assert.equal(report.build.channel, "self-built");
+  assert.equal(report.build.official, false);
+});
+
+test("keeps compatibility with reports that encode identity in the title", () => {
+  const sections = validSections();
+  delete sections["Game Name"];
+  delete sections["Title ID"];
+
+  const { report, errors } = helpers.normalizeIssueFormReport(
+    { title: "4D5307E6 — Halo 3" },
+    sections
+  );
+
+  assert.deepEqual(errors, []);
+  assert.equal(report.titleId, "4D5307E6");
+  assert.equal(report.title, "Halo 3");
+});
+
+test("rejects placeholder titles when the identity fields are absent", () => {
+  const sections = validSections();
+  delete sections["Game Name"];
+  delete sections["Title ID"];
+
+  const { report, errors } = helpers.normalizeIssueFormReport(
+    { title: "[TITLE_ID] — [GAME_NAME]" },
+    sections
+  );
+
+  assert.equal(report, null);
+  assert.match(errors[0], /Game Name/);
+});
+
+test("rejects impossible iOS architecture and GPU combinations", () => {
+  const { errors } = helpers.normalizeIssueFormReport(
+    { title: "[TITLE_ID] — [GAME_NAME]" },
+    validSections({
+      Architecture: "x86_64",
+      "GPU Backend": "MSC (Metal Shader Converter)",
+    })
+  );
+
+  assert.ok(errors.includes("iOS reports can only use ARM64."));
+  assert.ok(errors.includes("iOS reports can only use MSL."));
+});
+
+test("rejects incompatible status and performance combinations", () => {
+  const { errors } = helpers.normalizeIssueFormReport(
+    { title: "[TITLE_ID] — [GAME_NAME]" },
+    validSections({
+      "Compatibility Status": "Doesn't Boot — Does not boot or crashes immediately",
+      Performance: "Great — Runs at or near full speed",
+    })
+  );
+
+  assert.ok(errors.some((error) => error.includes('status "nothing"')));
+});


### PR DESCRIPTION
## What changed

- preserve trusted build metadata during canonical rebuilds
- collect Game Name and Title ID explicitly and canonicalize issue titles
- allow invalid reports to be corrected and reprocessed on edit
- validate status/performance and iOS architecture/backend combinations
- stop skipped or invalid reports before downstream rebuild, commit, and dispatch work
- add bounded retries for read-only GitHub API operations
- suppress no-op website mirror dispatches
- add focused compatibility parser tests

## Root cause

GitHub Issue Forms do not interpolate body fields into the issue title, so literal placeholder titles produced red workflow runs. Bot-created reports were correctly recognized as already processed but still ran expensive downstream steps, causing transient API errors and rejected pushes. Read-only rebuild requests also had no retry policy for GitHub 5xx and socket failures.

## Validation

- `node --test scripts/compat-data.test.cjs` (5 passing)
- `node --check scripts/build-discussions.mjs`
- actionlint
- issue-form YAML parse
- `git diff --check`
